### PR TITLE
#24 WIP: Server broadcasts game state to each player per tick

### DIFF
--- a/frontend/src/game/MessageBroker.ts
+++ b/frontend/src/game/MessageBroker.ts
@@ -15,9 +15,9 @@ const messageHandlers: Record<string, Function> = {
   [MessageEventType.NEW_PLAYER]: (data: NewPlayerMessage, scene: MainScene) => {
     scene.playerManager.playerJoined(data.color, data.name, data.x, data.y, data.id)
   },
-  [MessageEventType.PLAYER_MOVE]: (data: PlayerMoveMessage, scene: MainScene) => {
-    scene.playerManager.playerMoved(data.playerId, data.x, data.y, data.velocityX, data.velocityY)
-  },
+  // [MessageEventType.PLAYER_MOVE]: (data: PlayerMoveMessage, scene: MainScene) => {
+  //   scene.playerManager.playerMoved(data.playerId, data.x, data.y, data.velocityX, data.velocityY)
+  // },
   [MessageEventType.PLAYER_LEFT]: (data: PlayerLeftMessage, scene: MainScene) => {
     scene.playerManager.playerLeft(data.playerId)
   },
@@ -76,10 +76,11 @@ export class MessageBroker {
         data = message.data as GameStateMessage
         break
       default:
+        console.log(message.event, message.data)
         data = message.data
     }
 
-    messageHandlers[message.event](data, this.scene)
+    messageHandlers[message.event]?.(data, this.scene)
   }
 
   send(event: MessageEventType, data: SendableMessageData) {

--- a/frontend/src/game/PlayerManager.ts
+++ b/frontend/src/game/PlayerManager.ts
@@ -185,9 +185,28 @@ export class PlayerManager {
   }
 
   public updateGameState(players: Array<PlayerDataMessage>) {
-    players?.forEach((player) => {
-      if (!this.remotePlayers.find((p) => p.id === player.id)) {
-        this.addPlayer(player.color, player.name, false, player.x, player.y, player.id)
+    players?.forEach((playerData) => {
+      const player =
+        playerData.id === this.localPlayer.id
+          ? this.localPlayer
+          : this.remotePlayers.find((p) => p.id === playerData.id)
+      if (!player) {
+        this.addPlayer(
+          playerData.color,
+          playerData.name,
+          false,
+          playerData.x,
+          playerData.y,
+          playerData.id,
+        )
+      } else if (player !== this.localPlayer) {
+        this.playerMoved(
+          player,
+          playerData.x,
+          playerData.y,
+          playerData.velocityX,
+          playerData.velocityY,
+        )
       }
     })
   }
@@ -213,14 +232,11 @@ export class PlayerManager {
     this.scene.events.emit('message', `${name} joined`)
   }
 
-  public playerMoved(id: string, x: number, y: number, velocityX: number, velocityY: number) {
-    const playerUpdated = this.remotePlayers.find((player) => player.id === id)
-    if (playerUpdated) {
-      playerUpdated.sprite.x = x
-      playerUpdated.sprite.y = y
-      playerUpdated.sprite.body.setVelocityX(velocityX)
-      playerUpdated.sprite.body.setVelocityY(velocityY)
-    }
+  public playerMoved(player: Player, x: number, y: number, velocityX: number, velocityY: number) {
+    player.sprite.x = x
+    player.sprite.y = y
+    player.sprite.body.setVelocityX(velocityX)
+    player.sprite.body.setVelocityY(velocityY)
   }
 
   public playerLeft(id: string) {

--- a/src/Application.kt
+++ b/src/Application.kt
@@ -94,8 +94,6 @@ fun Application.module(testing: Boolean = false) {
         }
 
         webSocket("/ws/game") {
-//            send(Frame.Text("Hi from server"))
-
             MessageBroker.add(this)
 
             try {


### PR DESCRIPTION
This is a WIP

Current issues:
- The server tells each player where they themselves are (non-authoritative, just echoing back what it just heard), and the client ignores the data. This just adds unnecessary traffic
- Even when another player isn't moving, player A still receives data about player B having not moved (unnecessary traffic)
  - Since player A receives a "new" message about player B "moving", the sprite updates, and player B's trail never goes away